### PR TITLE
fix: make sure the type is set to "_doc" on ES7+

### DIFF
--- a/src/lib/elastic.js
+++ b/src/lib/elastic.js
@@ -99,6 +99,8 @@ function adjustBackendProxyUrl (req, indexName, entityType, config) {
 function adjustQuery (esQuery, entityType, config) {
   if (parseInt(config.elasticsearch.apiVersion) < 6) {
     esQuery.type = entityType
+  } else {
+    esQuery.type = '_doc';
   }
   esQuery.index = adjustIndexName(esQuery.index, entityType, config)
   return esQuery


### PR DESCRIPTION
When passing types to ES7, it will yield a warning and no results (tested on ES 7.9). This makes sure the type is always "_doc"