### PR TITLE
apiError instead of throws on develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bump version for `vsf-utilities` - @gibkigonzo (#495)
+- Responsing with error instead of throwing for broken /api/catalog paths - @Fifciu
 
 ## [1.12.2] - 2020.07.20
 

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -44,7 +44,10 @@ export default ({config, db}) => async function (req, res, body) {
   // Request method handling: exit if not GET or POST
   // Other methods - like PUT, DELETE etc. should be available only for authorized users or not available at all)
   if (!(req.method === 'GET' || req.method === 'POST' || req.method === 'OPTIONS')) {
-    throw new Error('ERROR: ' + req.method + ' request method is not supported.')
+    const errMessage = 'ERROR: ' + req.method + ' request method is not supported.';
+    console.error(errMessage);
+    apiError(res, errMessage);
+    return;
   }
 
   let responseFormat = 'standard'
@@ -54,7 +57,9 @@ export default ({config, db}) => async function (req, res, body) {
       try {
         requestBody = JSON.parse(decodeURIComponent(req.query.request))
       } catch (err) {
-        throw new Error(err)
+        console.error(err);
+        apiError(res, err);
+        return;
       }
     }
   }
@@ -69,17 +74,28 @@ export default ({config, db}) => async function (req, res, body) {
 
   let indexName = ''
   let entityType = ''
-  if (urlSegments.length < 2) { throw new Error('No index name given in the URL. Please do use following URL format: /api/catalog/<index_name>/<entity_type>_search') } else {
+  if (urlSegments.length < 2) {
+    const errMessage = 'No index name given in the URL. Please do use following URL format: /api/catalog/<index_name>/<entity_type>_search';
+    console.error(errMessage);
+    apiError(res, errMessage);
+    return;
+  } else {
     indexName = urlSegments[1]
 
     if (urlSegments.length > 2) { entityType = urlSegments[2] }
 
     if (config.elasticsearch.indices.indexOf(indexName) < 0) {
-      throw new Error('Invalid / inaccessible index name given in the URL. Please do use following URL format: /api/catalog/<index_name>/_search')
+      const errMessage = 'Invalid / inaccessible index name given in the URL. Please do use following URL format: /api/catalog/<index_name>/_search';
+      console.error(errMessage);
+      apiError(res, errMessage);
+      return;
     }
 
     if (urlSegments[urlSegments.length - 1].indexOf('_search') !== 0) {
-      throw new Error('Please do use following URL format: /api/catalog/<index_name>/_search')
+      const errMessage = 'Please do use following URL format: /api/catalog/<index_name>/_search';
+      console.error(errMessage);
+      apiError(res, errMessage);
+      return;
     }
   }
 


### PR DESCRIPTION
apiError instead of throws to prevent infinite load on broken /api/catalog links