### PR TITLE
Bugfix: Image file cache throws unhandled error if image not exists

### DIFF
--- a/src/api/img.ts
+++ b/src/api/img.ts
@@ -35,7 +35,7 @@ export default ({ config, db }) =>
     } else {
       await imageAction.prossesImage()
 
-      if (config.imageable.caching.active) {
+      if (config.imageable.caching.active && !imageAction.error) {
         cache.image = imageAction.imageBuffer
         await cache.save()
       }

--- a/src/image/action/local/index.ts
+++ b/src/image/action/local/index.ts
@@ -6,6 +6,7 @@ export default class LocalImageAction extends ImageAction {
   public imageOptions
   public SUPPORTED_MIMETYPES = ['image/gif', 'image/png', 'image/jpeg', 'image/webp', 'image/svg+xml']
   public imageBuffer: Buffer
+  public error = false
 
   public get whitelistDomain (): string[] {
     return this.options.imageable.whitelist
@@ -90,10 +91,18 @@ export default class LocalImageAction extends ImageAction {
     try {
       this.imageBuffer = await downloadImage(imgUrl)
     } catch (err) {
-      return this.res.status(400).send({
-        code: 400,
-        result: `Unable to download the requested image ${imgUrl}`
-      })
+      this.error = true
+      if (err.statusCode === 404) {
+        return this.res.status(404).send({
+          code: 404,
+          result: 'Not found'
+        })
+      } else {
+        return this.res.status(500).send({
+          code: 500,
+          result: `Unable to download the requested image ${imgUrl}`
+        })
+      }
     }
     const { action, width, height } = this.imageOptions
     switch (action) {


### PR DESCRIPTION
This only occurs when `config.imegable.caching.active === true`.

If a product image does not exists on the platform/backend the local image action will return empty.
The image file cache will still try to cache the result but fail, throwing an exception that will not be handled

This PR will add and `error` state to the `imageAction` and only cache the image if there is no error raised, thus preventing the unhandled error. I thought it would be better to not even try to cache if we know the is nothing to cache instead of just adding try/catch around the `cache.save()` statement.

I also created a specific edge case to forward the 404 not found status when the image is missing. I also changed the general image error status code from 400 to 500, because I thought it was more appropriate since it indicates an error with the server response and not an issue with the request.