### PR TITLE
Bugfix: Attributes cache tag and multistore handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.5] - Unreleased
+
+### Fixed
+- Fix caching of attributes. They were missing cache tag, preventing them from being purged correctly and also not separated cache key between multi stores (#583)
+
 ## [1.12.4] - 2021.01.15
 
 ### Fixed

--- a/src/api/attribute/service.ts
+++ b/src/api/attribute/service.ts
@@ -39,11 +39,11 @@ function transformAggsToAttributeListParam (aggregations): AttributeListParam {
 /**
  * Returns attributes from cache
  */
-async function getAttributeFromCache (attributeCode: string, config) {
+async function getAttributeFromCache (attributeCode: string, config, indexName) {
   if (config.server.useOutputCache && cache) {
     try {
       const res = await (cache as TagCache).get(
-        'api:attribute-list' + attributeCode
+        'api:' + indexName + ':attribute-list:' + attributeCode
       )
       return res
     } catch (err) {
@@ -56,12 +56,12 @@ async function getAttributeFromCache (attributeCode: string, config) {
 /**
  * Save attributes in cache
  */
-async function setAttributeInCache (attributeList, config) {
+async function setAttributeInCache (attributeList, config, indexName) {
   if (config.server.useOutputCache && cache) {
     try {
       await Promise.all(
         attributeList.map(attribute => (cache as TagCache).set(
-          'api:attribute-list' + attribute.attribute_code,
+          'api:' + indexName + ':attribute-list:' + attribute.attribute_code,
           attribute,
           ['attribute']
         ))
@@ -91,7 +91,7 @@ async function list (attributesParam: AttributeListParam, config, indexName: str
 
   // here we check if some of attribute are in cache
   const rawCachedAttributeList = await Promise.all(
-    attributeCodes.map(attributeCode => getAttributeFromCache(attributeCode, config))
+    attributeCodes.map(attributeCode => getAttributeFromCache(attributeCode, config, indexName))
   )
 
   const cachedAttributeList = rawCachedAttributeList
@@ -126,7 +126,7 @@ async function list (attributesParam: AttributeListParam, config, indexName: str
     const fetchedAttributeList = get(response.body, 'hits.hits', []).map(hit => hit._source)
 
     // save atrributes in cache
-    await setAttributeInCache(fetchedAttributeList, config)
+    await setAttributeInCache(fetchedAttributeList, config, indexName)
 
     // cached and fetched attributes
     const allAttributes = [

--- a/src/api/attribute/service.ts
+++ b/src/api/attribute/service.ts
@@ -62,7 +62,8 @@ async function setAttributeInCache (attributeList, config) {
       await Promise.all(
         attributeList.map(attribute => (cache as TagCache).set(
           'api:attribute-list' + attribute.attribute_code,
-          attribute
+          attribute,
+          ['attribute']
         ))
       )
     } catch (err) {


### PR DESCRIPTION
closes #579

* Adds cache tag attribute when caching so that attributes can be purged using cache tag
* Adds indexName to cache key so we store multistore attributes separately